### PR TITLE
use skip after https://github.com/pytest-dev/pytest/issues/3969 instead of xfail

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ MPI Tests always stop at the first error; because MPI is not fault tolerant [1].
         python run-tests.py --mpirun="mpirun -np 4"
     ```
 
-## Defining MPI UnitTests: MPITest decorator
+## Defining MPI UnitTests: 
 
 This feature may belong to a different package; it resides here for now before we can
 find a reasonable refactoring of the package.
+
+### MPITest decorator
 
 `MPITest` decorator allows testing with different MPI communicator sizes.
 
@@ -79,6 +81,40 @@ Example:
         result = myfunction(comm)
         assert result # or ....
 ```
+
+### MPITestFixture
+
+You cannot combine `MPITestFixture` with other pytest fixtures or decorators, what you can't with the `MPITest` decorator.
+
+Example: Parameter variation with `pytest.mark.parametrize`
+
+```python
+from runtests.mpi import MPITestFixture
+import pytest
+
+comm = MPITestFixture([1,2,3, 4,10], scope='function')
+
+@pytest.mark.parametrize("msg",["hello","world"])
+def test_y(msg, comm):
+    print(msg, comm.Get_rank())
+```
+
+Example: Parameter variation with `pytest.fixture`
+```bash
+from runtests.mpi import MPITestFixture
+import pytest
+
+comm = MPITestFixture([1,2,3,4], scope='function')
+
+@pytest.fixture(params=["hello","world"])
+def x(request):
+    return request.param
+
+def test_x(x, comm):
+    print(x, comm.Get_rank())
+```
+
+
 ## Tricks
 
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Example:
 
 ### MPITestFixture
 
-You cannot combine `MPITestFixture` with other pytest fixtures or decorators, what you can't with the `MPITest` decorator.
+You can combine `MPITestFixture` with other pytest fixtures or decorators, what you can't with the `MPITest` decorator.
 
 Example: Parameter variation with `pytest.mark.parametrize`
 
@@ -100,7 +100,7 @@ def test_y(msg, comm):
 ```
 
 Example: Parameter variation with `pytest.fixture`
-```bash
+```python
 from runtests.mpi import MPITestFixture
 import pytest
 

--- a/runtests/mpi/tester.py
+++ b/runtests/mpi/tester.py
@@ -84,16 +84,14 @@ def MPITestFixture(commsize, scope='function'):
         try:
             comm, color = create_comm(request.param)
 
-            # FIXME: use skip after https://github.com/pytest-dev/pytest/issues/3969 is figured out.
             if color != 0:
-                request.applymarker(pytest.mark.xfail(reason="Not using communicator %d" % request.param, run=False))
+                pytest.skip("Not using communicator %d" %(request.param))
                 return None
             else:
                 return comm
 
         except WorldTooSmall:
-            # FIXME: use skip after https://github.com/pytest-dev/pytest/issues/3969 is figured out.
-            request.applymarker(pytest.mark.xfail(reason="World is too small", run=False))
+            pytest.skip("Not using communicator %d" % request.param)
             return None
 
     return fixture


### PR DESCRIPTION
Changes not tested. I didn't get how to do it.

Question: why is MPITestfixture not mentioned in the doc ? It has the advantage to work together with other fixtures and pytest.mark.parametrize.