### PR TITLE
Fix coverage-5.x incompatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,10 @@ script:
     # regular unit tests
     #-------------------
     - python ./run-tests.py runtests/tests/test_regular.py
+    - python ./run-tests.py runtests/tests/test_regular.py --with-coverage
     - python ./run-mpitests.py --single runtests/tests/test_regular.py
     - python ./run-mpitests.py runtests/mpi/tests/test_mpiworld.py
+    - python ./run-mpitests.py runtests/tests/test_regular.py --with-coverage
     # expecting a failure for uncollective
     - if python ./run-mpitests.py runtests/mpi/tests/test_uncollective.py; then false; fi;
 


### PR DESCRIPTION
coverage-5.x switched to an implementation the preemptively creates
coverage data files. We need to play along.

I think this is compatible with coverage 4.x because we still
call the write function; but most devs will get coverage
5.x when they update runtests, so it shouldn't matter much even
if it is broken.

Fixes #24 

Added travis tests too.